### PR TITLE
adding option to re-create search with cli

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,5 +3,6 @@ MarkWiki was originally created by Matt Layman.
 Contributors
 ------------
 
+* deadc0de6
 * Matt Layman
 * Tim Miller

--- a/markwiki/server.py
+++ b/markwiki/server.py
@@ -6,6 +6,7 @@ import sys
 
 from markwiki import app
 from markwiki.freezer import freeze
+from markwiki.search.engine import SearchEngine
 
 
 def run():
@@ -28,12 +29,25 @@ def run():
         metavar='DESTINATION'
     )
 
+    parser.add_argument(
+        '-r', '--reindex',
+        action='store_true',
+        default=False,  # When no flag is provided.
+        help='force recreate the search index',
+        dest='reindex_search'
+    )
+
     args = parser.parse_args()
 
     # If a freezer destination was specified, then the wiki should be frozen.
     if args.freezer_destination:
         status = freeze(args.freezer_destination)
         # Quit after the wiki is frozen.
+        sys.exit(status)
+    if args.reindex_search:
+        app.search_engine = SearchEngine(app.config['MARKWIKI_HOME'])
+        status = app.search_engine.create_index(app.config['WIKI_PATH'])
+        # Quit after re-creating the search index
         sys.exit(status)
 
     app.run(app.config['SERVER_HOST'], app.config['SERVER_PORT'])

--- a/markwiki/views/core.py
+++ b/markwiki/views/core.py
@@ -182,3 +182,10 @@ def search():
     results = app.search_engine.search(user_query)
     return render_template('search.html', user_query=user_query,
                            results=results)
+
+@app.route('/reindex/')
+def reindex():
+    results = app.search_engine.create_index(app.config['WIKI_PATH'])
+    flash('Search index re-created', 'info')
+    '''Display the MarkWiki main page.'''
+    return redirect(url_for('index'))

--- a/markwiki/views/core.py
+++ b/markwiki/views/core.py
@@ -183,9 +183,9 @@ def search():
     return render_template('search.html', user_query=user_query,
                            results=results)
 
+
 @app.route('/reindex/')
 def reindex():
     results = app.search_engine.create_index(app.config['WIKI_PATH'])
     flash('Search index re-created', 'info')
-    '''Display the MarkWiki main page.'''
     return redirect(url_for('index'))


### PR DESCRIPTION
adding a client option (-r --reindex) to force creation of the index. This is useful when changing/adding pages directly on disk